### PR TITLE
Vagrantfile leverages new RancherOS capabilities

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+require_relative 'vagrant_rancheros_guest_plugin.rb'
+
 # To enable rsync folder share change to false
 $rsync_folder_disabled = true
+$number_of_nodes = 1
+$vm_mem = "1024"
+$vb_gui = false
 
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
@@ -10,20 +15,27 @@ $rsync_folder_disabled = true
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
-  config.vm.box       = "rancheros"
-  config.vm.box_url   = "http://cdn.rancher.io/vagrant/x86_64/prod/rancheros_v0.1.2_virtualbox.box"
-  config.ssh.username = "rancher"
+  config.vm.box   = "rancherio/rancheros"
+  config.vm.box_version = ">=0.2.0"
 
-  config.vm.provider "virtualbox" do |vb|
-     vb.check_guest_additions = false
-     vb.functional_vboxsf     = false
-     vb.memory = "1024"
+  (1..$number_of_nodes).each do |i|
+    hostname = "rancher-%02d" % i
+
+    config.vm.define hostname do |node|
+        node.vm.provider "virtualbox" do |vb|
+            vb.memory = $vm_mem
+            vb.gui = $vb_gui
+        end
+
+        ip = "172.19.8.#{i+100}"
+        node.vm.network "private_network", ip: ip
+
+        # Disabling compression because OS X has an ancient version of rsync installed.
+        # Add -z or remove rsync__args below if you have a newer version of rsync on your machine.
+        node.vm.synced_folder ".", "/opt/rancher", type: "rsync",
+            rsync__exclude: ".git/", rsync__args: ["--verbose", "--archive", "--delete", "--copy-links"],
+            disabled: $rsync_folder_disabled
+
+    end
   end
-
-  # Disabling compression because OS X has an ancient version of rsync installed.
-  # Add -z or remove rsync__args below if you have a newer version of rsync on your machine.
-  config.vm.synced_folder ".", "/opt/rancher", type: "rsync",
-    rsync__exclude: ".git/", rsync__args: ["--verbose", "--archive", "--delete", "--copy-links"],
-    disabled: $rsync_folder_disabled
-
 end

--- a/vagrant_rancheros_guest_plugin.rb
+++ b/vagrant_rancheros_guest_plugin.rb
@@ -1,0 +1,50 @@
+require 'ipaddr'
+
+## Hacking this until we get a real plugin
+
+# Borrowing from http://stackoverflow.com/questions/1825928/netmask-to-cidr-in-ruby
+IPAddr.class_eval do
+  def to_cidr
+    self.to_i.to_s(2).count("1")
+  end
+end
+
+module VagrantPlugins
+    module GuestLinux
+        class Plugin < Vagrant.plugin("2")
+            guest_capability("linux", "configure_networks") do
+                Cap::ConfigureNetworks
+            end
+        end
+
+        module Cap
+            class ConfigureNetworks
+
+                def self.configure_networks(machine, networks)
+                    machine.communicate.tap do |comm|
+                        interfaces = []
+                        comm.sudo("ip link show|grep eth[1-9]|awk -e '{print $2}'|sed -e 's/:$//'") do |_, result|
+                            interfaces = result.split("\n")
+                        end
+
+                        networks.each do |network|
+                            dhcp = "true"
+                            iface = interfaces[network[:interface].to_i - 1]
+
+                            if network[:type] == :static
+                                cidr = IPAddr.new(network[:netmask]).to_cidr
+                                comm.sudo("rancherctl config set network.interfaces.#{iface}.address #{network[:ip]}/#{cidr}")
+                                comm.sudo("rancherctl config set network.interfaces.#{iface}.match #{iface}")
+
+                                dhcp = "false"
+                            end
+                            comm.sudo("rancherctl config set network.interfaces.#{iface}.dhcp #{dhcp}")
+                        end
+
+                        comm.sudo("system-docker restart network")
+                    end
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
You can now specify additional network interfaces in the Vagrantfile.
There is a plugin added to bootstrap the functionality until we get it
right and can make it an official plugin.

Made it easier to specify multiple nodes.
