### PR TITLE
Disable vbguest plugin auto update if applicable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,10 @@ Vagrant.configure(2) do |config|
   config.vm.box   = "rancherio/rancheros"
   config.vm.box_version = ">=0.3.3"
 
+  if Vagrant.has_plugin?("vagrant-vbguest")
+    config.vbguest.auto_update = false
+  end
+
   (1..$number_of_nodes).each do |i|
     hostname = "rancher-%02d" % i
 


### PR DESCRIPTION
vagrant-vbguest plugin is widely used to automatically install host's VirtualBox Guest Additions on the guest system. If the plugin is installed, starting the vm fails on mounting VBoxGuestAdditions.iso and provisioning is not completed.

This is rather a workaround unless we don't need to install VBoxGuestAdditions at all.
