### PR TITLE
prevent vagrant-vbguest trying to install VirtualBox Guest Additions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,11 @@ Vagrant.configure(2) do |config|
   config.vm.box   = "rancherio/rancheros"
   config.vm.box_version = ">=0.4.1"
 
+  # prevent vagrant-vbguest trying to install VirtualBox Guest Additions
+  if Vagrant.has_plugin?("vagrant-vbguest")
+    config.vbguest.no_install = true
+  end  
+
   (1..$number_of_nodes).each do |i|
     hostname = "rancher-%02d" % i
 


### PR DESCRIPTION
os-vagrant issue #12 

If the vbguest plugin is installed, it is disabled. This removes a stumbling block for new users.
