### PR TITLE
fix a guest OS error

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure(2) do |config|
 
   (1..$number_of_nodes).each do |i|
     hostname = "rancher-%02d" % i
-
+    config.vm.guest = :linux
     config.vm.define hostname do |node|
         node.vm.provider "virtualbox" do |vb|
             vb.memory = $vm_mem


### PR DESCRIPTION
In my Mac OS(Sierra var 10.12.3) environment, guest OS error occurred as the following..

Versions on my env:
Host OS: Mac OS Sierra var 10.12.3
Vagrant: 1.9.1
Virtual Box: Version 5.0.30
 
```shell
Bringing machine 'rancher-01' up with 'virtualbox' provider...
==> rancher-01: Importing base box 'rancherio/rancheros'...
==> rancher-01: Matching MAC address for NAT networking...
==> rancher-01: Checking if box 'rancherio/rancheros' is up to date...
==> rancher-01: Setting the name of the VM: rancherOS_rancher-01_1485725552385_23893
==> rancher-01: Clearing any previously set network interfaces...
==> rancher-01: Preparing network interfaces based on configuration...
    rancher-01: Adapter 1: nat
    rancher-01: Adapter 2: hostonly
==> rancher-01: Forwarding ports...
    rancher-01: 22 (guest) => 2222 (host) (adapter 1)
==> rancher-01: Running 'pre-boot' VM customizations...
==> rancher-01: Booting VM...
==> rancher-01: Waiting for machine to boot. This may take a few minutes...
    rancher-01: SSH address: 127.0.0.1:2222
    rancher-01: SSH username: rancher
    rancher-01: SSH auth method: private key
    rancher-01: Warning: Remote connection disconnect. Retrying...
    rancher-01:
    rancher-01: Vagrant insecure key detected. Vagrant will automatically replace
    rancher-01: this with a newly generated keypair for better security.
==> rancher-01: Machine booted and ready!
==> rancher-01: Setting hostname...
The guest operating system of the machine could not be detected!
Vagrant requires this knowledge to perform specific tasks such
as mounting shared folders and configuring networks. Please add
the ability to detect this guest operating system to Vagrant
by creating a plugin or reporting a bug.
```

I fixed Vagrantfile. After that, It seems fine to me.
I added simple line bellow.
```ruby
config.vm.guest = :linux
```
Pls make sure that and merge it.